### PR TITLE
Fixed compile issue on arch linux

### DIFF
--- a/src/node-cvc4.cpp
+++ b/src/node-cvc4.cpp
@@ -27,8 +27,10 @@ namespace node_cvc4 {
 
 inline Local <String>
 to_javascript(Isolate *isolate, const std::string &s) {
-    return v8::String::NewFromOneByte(isolate, (const uint8_t *) s.data(),
-                                      v8::String::NewStringType::kNormalString, s.length());
+    Local<String> ret;
+    v8::String::NewFromOneByte(isolate, (const uint8_t *) s.data(),
+                               v8::NewStringType::kNormal, s.length()).ToLocal(&ret);
+    return ret;
 }
 std::string
 v8_to_string(const Local <v8::String> &s) {
@@ -43,7 +45,10 @@ v8_to_string(const Local <v8::String> &s) {
 
 v8::Local <v8::Value>
 exception_to_v8(Isolate *isolate, const char *error_msg) {
-    Local <String> v8_message = v8::String::NewFromOneByte(isolate, (uint8_t *) error_msg);
+    std::string error_msg_str{error_msg};
+    Local<String> v8_message;
+    v8::String::NewFromOneByte(isolate, (const uint8_t *) error_msg_str.data(),
+                               v8::NewStringType::kNormal, error_msg_str.length()).ToLocal(&v8_message);
     return v8::Exception::Error(v8_message);
 }
 


### PR DESCRIPTION
On an up-to-date Arch Linux, got messages below when trying to build (originally discovered trying to build almond-cmdline). It appears you are using a number of deprecated V8 API calls, some of which have now been completely removed. I wacked the code a few times until it worked. Tests seem to pass, but I don't know these APIs so it could have been done in a rather stupid way. There are still deprecation warnings, so it might be a good idea the update the rest of the file before it all starts breaking.

original output:
```
william:node-cvc4$ yarn
yarn install v1.7.0
info No lockfile found.
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
$ node-gyp rebuild
[###---] 3/6gyp info it worked if it ends with ok
gyp info using node-gyp@3.7.0
gyp info using node@10.6.0 | linux | x64
gyp info spawn /usr/bin/python2
gyp info spawn args [ '/usr/lib/node_modules/node-gyp/gyp/gyp_main.py',
gyp info spawn args   'binding.gyp',
gyp info spawn args   '-f',
gyp info spawn args   'make',
gyp info spawn args   '-I',
gyp info spawn args   '/home/william/extern/node-cvc4/build/config.gypi',
gyp info spawn args   '-I',
gyp info spawn args   '/usr/lib/node_modules/node-gyp/addon.gypi',
gyp info spawn args   '-I',
gyp info spawn args   '/home/william/.node-gyp/10.6.0/include/node/common.gypi',
gyp info spawn args   '-Dlibrary=shared_library',
gyp info spawn args   '-Dvisibility=default',
gyp info spawn args   '-Dnode_root_dir=/home/william/.node-gyp/10.6.0',
gyp info spawn args   '-Dnode_gyp_dir=/usr/lib/node_modules/node-gyp',
gyp info spawn args   '-Dnode_lib_file=/home/william/.node-gyp/10.6.0/<(target_arch)/node.lib',
gyp info spawn args   '-Dmodule_root_dir=/home/william/extern/node-cvc4',
gyp info spawn args   '-Dnode_engine=v8',
gyp info spawn args   '--depth=.',
gyp info spawn args   '--no-parallel',
gyp info spawn args   '--generator-output',
gyp info spawn args   'build',
gyp info spawn args   '-Goutput_dir=.' ]
gyp info spawn make
gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
make: Entering directory '/home/william/extern/node-cvc4/build'
  CXX(target) Release/obj.target/cvc4/src/node-cvc4.o
In file included from /usr/include/c++/8.1.1/ext/hash_map:60,
                 from /usr/include/cvc4/util/hash.h:26,
                 from /usr/include/cvc4/expr/record.h:26,
                 from /usr/include/cvc4/expr/expr.h:90,
                 from /usr/include/cvc4/expr/datatype.h:36,
                 from /usr/include/cvc4/cvc4.h:23,
                 from ../src/node-cvc4.cpp:12:
/usr/include/c++/8.1.1/backward/backward_warning.h:32:2: warning: #warning This file includes at least one deprecated or antiquated header which may be removed without further notice at a future date. Please use a non-deprecated interface with equivalent functionality instead. For a listing of replacement headers and interfaces, consult the file backward_warning.h. To disable this warning use -Wno-deprecated. [-Wcpp]
 #warning \
  ^~~~~~~
../src/node-cvc4.cpp: In function ‘v8::Local<v8::String> node_cvc4::to_javascript(v8::Isolate*, const string&)’:
../src/node-cvc4.cpp:31:91: error: no matching function for call to ‘v8::String::NewFromOneByte(v8::Isolate*&, const uint8_t*, v8::String::NewStringType, std::__cxx11::basic_string<char>::size_type)’
                                       v8::String::NewStringType::kNormalString, s.length());
                                                                                           ^
In file included from /home/william/.node-gyp/10.6.0/include/node/node.h:63,
                 from ../src/node-cvc4.cpp:9:
/home/william/.node-gyp/10.6.0/include/node/v8.h:2766:51: note: candidate: ‘static v8::MaybeLocal<v8::String> v8::String::NewFromOneByte(v8::Isolate*, const uint8_t*, v8::NewStringType, int)’
   static V8_WARN_UNUSED_RESULT MaybeLocal<String> NewFromOneByte(
                                                   ^~~~~~~~~~~~~~
/home/william/.node-gyp/10.6.0/include/node/v8.h:2766:51: note:   no known conversion for argument 3 from ‘v8::String::NewStringType’ to ‘v8::NewStringType’
../src/node-cvc4.cpp: In function ‘v8::Local<v8::Value> node_cvc4::exception_to_v8(v8::Isolate*, const char*)’:
../src/node-cvc4.cpp:46:90: error: no matching function for call to ‘v8::String::NewFromOneByte(v8::Isolate*&, uint8_t*)’
     Local <String> v8_message = v8::String::NewFromOneByte(isolate, (uint8_t *) error_msg);
                                                                                          ^
In file included from /home/william/.node-gyp/10.6.0/include/node/node.h:63,
                 from ../src/node-cvc4.cpp:9:
/home/william/.node-gyp/10.6.0/include/node/v8.h:2766:51: note: candidate: ‘static v8::MaybeLocal<v8::String> v8::String::NewFromOneByte(v8::Isolate*, const uint8_t*, v8::NewStringType, int)’
   static V8_WARN_UNUSED_RESULT MaybeLocal<String> NewFromOneByte(
                                                   ^~~~~~~~~~~~~~
/home/william/.node-gyp/10.6.0/include/node/v8.h:2766:51: note:   candidate expects 4 arguments, 2 provided
../src/node-cvc4.cpp: In constructor ‘node_cvc4::UVAsyncCall<T>::UVAsyncCall(v8::Isolate*, Callable&&)’:
../src/node-cvc4.cpp:64:99: warning: ‘static v8::Local<v8::Promise::Resolver> v8::Promise::Resolver::New(v8::Isolate*)’ is deprecated: Use maybe version [-Wdeprecated-declarations]
         js_promise = v8::Global<v8::Promise::Resolver>(isolate, v8::Promise::Resolver::New(isolate));
                                                                                                   ^
In file included from /home/william/.node-gyp/10.6.0/include/node/v8.h:26,
                 from /home/william/.node-gyp/10.6.0/include/node/node.h:63,
                 from ../src/node-cvc4.cpp:9:
/home/william/.node-gyp/10.6.0/include/node/v8.h:4002:42: note: declared here
                          Local<Resolver> New(Isolate* isolate));
                                          ^~~
/home/william/.node-gyp/10.6.0/include/node/v8config.h:324:3: note: in definition of macro ‘V8_DEPRECATED’
   declarator __attribute__((deprecated(message)))
   ^~~~~~~~~~
../src/node-cvc4.cpp: In instantiation of ‘node_cvc4::UVAsyncCall<T>::UVAsyncCall(v8::Isolate*, Callable&&) [with Callable = node_cvc4::solver_call; T = std::__cxx11::basic_string<char>]’:
../src/node-cvc4.cpp:96:37:   required from ‘v8::Local<v8::Promise> node_cvc4::Schedule(v8::Isolate*, Callable&&) [with Callable = node_cvc4::solver_call]’
../src/node-cvc4.cpp:200:74:   required from here
../src/node-cvc4.cpp:64:91: warning: ‘static v8::Local<v8::Promise::Resolver> v8::Promise::Resolver::New(v8::Isolate*)’ is deprecated: Use maybe version [-Wdeprecated-declarations]
         js_promise = v8::Global<v8::Promise::Resolver>(isolate, v8::Promise::Resolver::New(isolate));
                                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
In file included from /home/william/.node-gyp/10.6.0/include/node/v8.h:26,
                 from /home/william/.node-gyp/10.6.0/include/node/node.h:63,
                 from ../src/node-cvc4.cpp:9:
/home/william/.node-gyp/10.6.0/include/node/v8.h:4002:42: note: declared here
                          Local<Resolver> New(Isolate* isolate));
                                          ^~~
/home/william/.node-gyp/10.6.0/include/node/v8config.h:324:3: note: in definition of macro ‘V8_DEPRECATED’
   declarator __attribute__((deprecated(message)))
   ^~~~~~~~~~
../src/node-cvc4.cpp:64:91: warning: ‘static v8::Local<v8::Promise::Resolver> v8::Promise::Resolver::New(v8::Isolate*)’ is deprecated: Use maybe version [-Wdeprecated-declarations]
         js_promise = v8::Global<v8::Promise::Resolver>(isolate, v8::Promise::Resolver::New(isolate));
                                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
In file included from /home/william/.node-gyp/10.6.0/include/node/v8.h:26,
                 from /home/william/.node-gyp/10.6.0/include/node/node.h:63,
                 from ../src/node-cvc4.cpp:9:
/home/william/.node-gyp/10.6.0/include/node/v8.h:4002:42: note: declared here
                          Local<Resolver> New(Isolate* isolate));
                                          ^~~
/home/william/.node-gyp/10.6.0/include/node/v8config.h:324:3: note: in definition of macro ‘V8_DEPRECATED’
   declarator __attribute__((deprecated(message)))
   ^~~~~~~~~~
../src/node-cvc4.cpp: In instantiation of ‘static void node_cvc4::UVAsyncCall<T>::do_after_work(uv_work_t*, int) [with T = std::__cxx11::basic_string<char>; uv_work_t = uv_work_s]’:
../src/node-cvc4.cpp:100:79:   required from ‘v8::Local<v8::Promise> node_cvc4::Schedule(v8::Isolate*, Callable&&) [with Callable = node_cvc4::solver_call]’
../src/node-cvc4.cpp:200:74:   required from here
../src/node-cvc4.cpp:81:17: warning: ‘void v8::Promise::Resolver::Resolve(v8::Local<v8::Value>)’ is deprecated: Use maybe version [-Wdeprecated-declarations]
                 promise->Resolve(to_javascript(isolate, value));
                 ^~~~~~~
In file included from /home/william/.node-gyp/10.6.0/include/node/v8.h:26,
                 from /home/william/.node-gyp/10.6.0/include/node/node.h:63,
                 from ../src/node-cvc4.cpp:9:
/home/william/.node-gyp/10.6.0/include/node/v8.h:4015:45: note: declared here
     V8_DEPRECATED("Use maybe version", void Resolve(Local<Value> value));
                                             ^~~~~~~
/home/william/.node-gyp/10.6.0/include/node/v8config.h:324:3: note: in definition of macro ‘V8_DEPRECATED’
   declarator __attribute__((deprecated(message)))
   ^~~~~~~~~~
../src/node-cvc4.cpp:83:32: warning: ‘void v8::Promise::Resolver::Reject(v8::Local<v8::Value>)’ is deprecated: Use maybe version [-Wdeprecated-declarations]
                 promise->Reject(exception_to_v8(isolate, e.what()));
                 ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/william/.node-gyp/10.6.0/include/node/v8.h:26,
                 from /home/william/.node-gyp/10.6.0/include/node/node.h:63,
                 from ../src/node-cvc4.cpp:9:
/home/william/.node-gyp/10.6.0/include/node/v8.h:4019:45: note: declared here
     V8_DEPRECATED("Use maybe version", void Reject(Local<Value> value));
                                             ^~~~~~
/home/william/.node-gyp/10.6.0/include/node/v8config.h:324:3: note: in definition of macro ‘V8_DEPRECATED’
   declarator __attribute__((deprecated(message)))
   ^~~~~~~~~~
make: *** [cvc4.target.mk:101: Release/obj.target/cvc4/src/node-cvc4.o] Error 1
make: Leaving directory '/home/william/extern/node-cvc4/build'
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/usr/lib/node_modules/node-gyp/lib/build.js:262:23)
gyp ERR! stack     at ChildProcess.emit (events.js:182:13)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:237:12)
gyp ERR! System Linux 4.17.5-1-ARCH
gyp ERR! command "/usr/bin/node" "/usr/bin/node-gyp" "rebuild"
gyp ERR! cwd /home/william/extern/node-cvc4
gyp ERR! node -v v10.6.0
gyp ERR! node-gyp -v v3.7.0
gyp ERR! not ok 
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```